### PR TITLE
Add Meraki MX Site-to-Site VPN Preset Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,43 @@ configured in your VPN Connection endpoint in Amazon.
 #### `ipsec_2_psk`
 (Line 109 of the Generic VPC Configuration from Amazon)
 
+### Definition: strongswan::presets::meraki\_vpn
+
+Configures an incoming VPN service for a Meraki MX-series router using IKEv1
+per their
+[documentation](https://kb.meraki.com/knowledge_base/troubleshooting-3rd-party-site-to-site-vpn).
+
+```puppet
+strongswan::presets::meraki_vpn { 'our-office':
+  meraki_public_ip => <your meraki/office public ip address>,
+  meraki_subnet    => <your internal office subnet>,
+  swan_public_ip   => <your strongswan server public address>,
+  swan_subnet      => <your strongswan server private subnet>,
+  psk              => <pre-shared-key>
+  masquerade       => <whether or not to enable ip masquerading>
+}
+```
+
+#### `meraki_public_ip`
+The Public IPv4 address that your Meraki has on the Internet. Used to
+configure inbound access through the Firewall to the network
+
+#### `meraki_subnet`
+The IP CIDR that your Meraki is hosting behind it. Likely matches the range
+described in the 'Local networks' section of the site-to-site VPN page.
+
+#### `swan_public_ip`
+The public IP address of the strongSwan server -- used to help handle
+NAT-Traversal issues.
+
+#### `swan_subnet`
+The IP CIDR that you want your strongSwan server to provide access to your
+Merakis. Should exactly match the _Private subnets_ configuration option in
+the Meraki site-to-site VPN page.
+
+#### `psk`
+The pre-shared-key you've entered into your Meraki site-to-site VPN page.
+
+#### `masquerade`
+Either `present` or `absent`: Whether or not to enable IP masquerading on the
+strongSwan host.

--- a/manifests/presets/meraki_vpn.pp
+++ b/manifests/presets/meraki_vpn.pp
@@ -1,0 +1,113 @@
+# == Define: strongswan::presets::meraki_vpn
+#
+# Sets up Strongswan to accept inbound VPN connection requests from Meraki
+# MX-series security appliances. Configured to accept the 'default'
+# _IPSec policies_ as described on the _Site-to-site VPN_ management page.
+#
+# === Required Parameters
+#
+# [*meraki_public_ip*]
+#   The Public IPv4 address that your Meraki has on the Internet. Used to
+#   configure inbound access through the Firewall to the network.
+#
+# [*meraki_subnet*]
+#   The IP CIDR that your Meraki is hosting behind it. Likely matches the range
+#   described in the 'Local networks' section of the site-to-site VPN page.
+#
+# [*swan_public_ip*]
+#   The public IP address of the strongSwan server -- used to help handle
+#   NAT-Traversal issues.
+#
+# [*swan_subnet*]
+#   The IP CIDR that you want your strongSwan server to provide access to your
+#   Merakis. Should exactly match the _Private subnets_ configuration option in
+#   the Meraki site-to-site VPN page.
+#
+# [*psk*]
+#   Pre-shared-key configured in the Meraki site-to-site VPN page.
+#
+# === Optional Parameters
+#
+# [*masquerade*]
+#   Present/Absent: Whether or not to masquerade traffic to the _private_subnet_ from
+#   the Meraki IPs.
+#   (default: True)
+#
+# === Authors
+#
+# Matt Wise
+#
+define strongswan::presets::meraki_vpn (
+  $meraki_public_ip,
+  $meraki_subnet,
+  $swan_public_ip,
+  $swan_subnet,
+  $psk,
+  $masquerade = present,
+) {
+  # This configuration works with the 'default' IPSec policies defined in
+  # Meraki MX-series security appliances.
+  $_params = {
+    'authby'        => 'secret',
+    'auto'          => 'add',
+    'ikelifetime'   => '8h',
+    'keyexchange'   => 'ikev1',
+    'ike'           => '3des-sha1',
+    'esp'           => 'aes256-sha1-noesn',
+    'keylife'       => '8h',
+    'rekeymargin'   => '3m',
+
+    'left'          => $::ipaddress,
+    'leftid'        => $swan_public_ip,
+    'leftsubnet'    => $swan_subnet,
+    'right'         => $meraki_public_ip,
+    'rightsubnet'   => $meraki_subnet,
+  }
+
+  $_secrets = [
+  # All employees are given this PSK. This PSK is the first authenticator
+  # before they move into the Phase2 (PAM) auth.
+    { 'left_id'  => $::ipaddress,
+      'right_id' => $meraki_public_ip,
+      'auth'     => 'PSK',
+      'key'      => $psk }
+  ]
+
+  # Make sure the strongswan service has been configured
+  include strongswan
+  include strongswan::env
+
+  # Ensure that inbound VPN requests are allowed
+  firewall {
+    "020 ${title} inbound udp":
+    proto  => 'udp',
+    action => 'accept',
+    source => $meraki_public_ip,
+    dport  => $strongswan::env::ports;
+
+    "020 ${title} masquerading":
+    ensure   => $masquerade,
+    chain    => 'POSTROUTING',
+    jump     => 'MASQUERADE',
+    proto    => all,
+    outiface => 'eth0',
+    source   => $meraki_subnet,
+    table    => 'nat';
+
+    "021 ${title} ipsec routing policy":
+    chain        => 'POSTROUTING',
+    action       => 'accept',
+    proto        => all,
+    outiface     => 'eth0',
+    source       => $meraki_subnet,
+    ipsec_policy => 'ipsec',
+    ipsec_dir    => 'out',
+    table        => 'nat';
+  }
+
+  # Now set up the actual Strongswan configuration
+  strongswan::conn { "${title}":
+    params  => $_params,
+    secrets => $_secrets,
+  }
+}

--- a/spec/defines/presets_meraki_vpn_spec.rb
+++ b/spec/defines/presets_meraki_vpn_spec.rb
@@ -5,8 +5,8 @@ describe 'strongswan::presets::meraki_vpn', :type => 'define' do
 
   context 'main test' do
     let(:params) {{
-      :meraki_public_ip => 'MERAKI_PUBLIC_IP',
-      :meraki_subnet    => 'MERAKI_SUBNET',
+      :meraki_public_ip => '123.123.123.123',
+      :meraki_subnet    => '192.168.0.0/24',
       :swan_public_ip   => 'SWAN_PUBLIC_IP',
       :swan_subnet      => 'SWAN_SUBNET',
       :psk              => 'PSK',
@@ -18,15 +18,15 @@ describe 'strongswan::presets::meraki_vpn', :type => 'define' do
       should contain_class('strongswan::env')
 
       should contain_firewall('020 UNITTEST inbound udp').with(
-        'source' => 'MERAKI_SUBNET')
+        'source' => '123.123.123.123')
       should contain_firewall('020 UNITTEST masquerading').with(
         'ensure' => 'present',
-        'source' => 'MERAKI_SUBNET')
-      should contain_firewall('020 UNITTEST ipsec routing policy').with(
-        'source' => 'MERAKI_SUBNET')
+        'source' => '192.168.0.0/24')
+      should contain_firewall('021 UNITTEST ipsec routing policy').with(
+        'source' => '192.168.0.0/24')
 
       should contain_strongswan__conn('UNITTEST').with(
-        'params'  => /MERAKI_PUBLIC_IP/,
+        'params'  => /123.123.123.123/,
         'secrets' => /PSK/)
     end
   end

--- a/spec/defines/presets_meraki_vpn_spec.rb
+++ b/spec/defines/presets_meraki_vpn_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe 'strongswan::presets::meraki_vpn', :type => 'define' do
+  let(:title) { 'UNITTEST' }
+
+  context 'main test' do
+    let(:params) {{
+      :meraki_public_ip => 'MERAKI_PUBLIC_IP',
+      :meraki_subnet    => 'MERAKI_SUBNET',
+      :swan_public_ip   => 'SWAN_PUBLIC_IP',
+      :swan_subnet      => 'SWAN_SUBNET',
+      :psk              => 'PSK',
+      :masquerade       => 'present',
+    }}
+    it do
+      should compile.with_all_deps
+      should contain_class('strongswan')
+      should contain_class('strongswan::env')
+
+      should contain_firewall('020 UNITTEST inbound udp').with(
+        'source' => 'MERAKI_SUBNET')
+      should contain_firewall('020 UNITTEST masquerading').with(
+        'ensure' => 'present',
+        'source' => 'MERAKI_SUBNET')
+      should contain_firewall('020 UNITTEST ipsec routing policy').with(
+        'source' => 'MERAKI_SUBNET')
+
+      should contain_strongswan__conn('UNITTEST').with(
+        'params'  => /MERAKI_PUBLIC_IP/,
+        'secrets' => /PSK/)
+    end
+  end
+end


### PR DESCRIPTION
Simple definition to creating a site-to-site VPN service for a Meraki MX-series security appliance using PSKs.