### PR TITLE
Legacy Support

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -104,10 +104,27 @@ class strongswan::config (
     content   => template('strongswan/ipsec.secrets.erb');
   }
 
+  $strongswan_d = '/etc/strongswan.d'
+  $charon_conf = "${strongswan_d}/charon.conf"
+
+  # Ensure settings from strongwan.d are included.
+  file { $strongswan_d:
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+
+  file_line { 'include-strongswan.d':
+    ensure => present,
+    path   => '/etc/strongswan.conf',
+    line   => 'include strongswan.d/*.conf',
+  }
+
   # Merge the supplied charon configuration options and generate the charon
-  # config file
+  # config file.
   $_charon_options = merge($strongswan::env::charon_options, $charon_options)
-  file { '/etc/strongswan.d/charon.conf':
+  file { $charon_conf:
     ensure  => file,
     owner   => 'root',
     group   => 'root',

--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -17,7 +17,13 @@ class strongswan::env {
                           'strongswan-plugin-xauth-pam' ]
 
   # Service configuration options
-  $service_name   = 'strongswan'
+  if $::lsbdistcodename in ['precise', 'wheezy'] {
+    $strongswan_4 = true
+    $service_name = 'ipsec'
+  } else {
+    $strongswan_4 = false
+    $service_name = 'strongswan'
+  }
   $service_ensure = 'running'
   $service_enable = true
 

--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -18,10 +18,8 @@ class strongswan::env {
 
   # Service configuration options
   if $::lsbdistcodename in ['precise', 'wheezy'] {
-    $strongswan_4 = true
     $service_name = 'ipsec'
   } else {
-    $strongswan_4 = false
     $service_name = 'strongswan'
   }
   $service_ensure = 'running'

--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -17,7 +17,7 @@ class strongswan::env {
                           'strongswan-plugin-xauth-pam' ]
 
   # Service configuration options
-  if $::lsbdistcodename in ['precise', 'wheezy'] {
+  if $::lsbdistcodename in ['precise', 'squeeze', 'wheezy'] {
     $service_name = 'ipsec'
   } else {
     $service_name = 'strongswan'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -12,11 +12,8 @@ class strongswan::service (
   $enable  = $strongswan::env::service_enable,
 ) inherits strongswan::env {
   service { 'strongswan':
-    ensure     => $ensure,
-    provider   => 'upstart',
-    name       => $service,
-    enable     => $enable,
-    hasstatus  => true,
-    hasrestart => true,
+    ensure => $ensure,
+    name   => $service,
+    enable => $enable,
   }
 }


### PR DESCRIPTION
This PR adds support for the Debian-based platforms that use Strongswan 4.x packages (Ubuntu 12.04 and Debian 6/7).  Although the [`metadata.json`](https://github.com/Nextdoor/puppet-strongswan/blob/master/metadata.json#L23) implies that the module supports 12.04 and Debian 6/7, it doesn't currently work (should probably remove 10.04 as it's officially EOL now too).

* Use `ipsec` as service name on legacy platforms.  Also, let puppet determine the service provider automatically, as upstart isn't used in 4.x versions -- this also helps to future-proof considering the switch to systemd in Debian 8 and 16.04.
* Ensure existence of `/etc/strongswan.d`, and inclusion of it from `/etc/strongswan.conf` so that charon configuration settings will work (this isn't done in 4.x packages).
