### PR TITLE
Connection Secrets Tweaks

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,11 +1,6 @@
 fixtures:
-  repositories:
-    "stdlib":
-      "repo": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-      "ref": "v2.2.1"
-    "firewall":
-      "repo": "git://github.com/puppetlabs/puppetlabs-firewall.git"
-      "ref": "1.3.0"
-  symlinks:
+  forge_modules:
+    firewall: 'puppetlabs/firewall'
+    stdlib: 'puppetlabs/stdlib'
   symlinks:
     "strongswan": "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ script:
   - "bundle exec rake lint"
   - "bundle exec rake spec SPEC_OPTS='--format documentation --color'"
 rvm:
-  - 1.8.7
+#  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:

--- a/manifests/conn.pp
+++ b/manifests/conn.pp
@@ -33,7 +33,7 @@ define strongswan::conn (
   $_conn_conf_path    = $strongswan::config::conn_conf_path
   $_secrets_conf_path = $strongswan::config::secrets_conf_path
 
-  file { "${_conn_conf_path}/ipsec.${name}.conf":
+  file { "${_conn_conf_path}/ipsec.${title}.conf":
     ensure  => file,
     owner   => 'root',
     group   => 'root',
@@ -43,8 +43,15 @@ define strongswan::conn (
     require => Class['strongswan::config'];
   }
 
-  file { "${_secrets_conf_path}/ipsec.${name}.secrets":
-    ensure    => file,
+  $secrets_conf = "${_secrets_conf_path}/ipsec.${title}.secrets"
+  if count($secrets) > 0 {
+    $secrets_ensure = 'file'
+  } else {
+    $secrets_ensure = 'absent'
+  }
+
+  file { $secrets_conf:
+    ensure    => $secrets_ensure,
     owner     => 'root',
     group     => 'root',
     mode      => '0600',

--- a/manifests/conn.pp
+++ b/manifests/conn.pp
@@ -55,6 +55,7 @@ define strongswan::conn (
     owner     => 'root',
     group     => 'root',
     mode      => '0600',
+    backup    => false,
     show_diff => false,
     content   => template('strongswan/ipsec.conn.secrets.erb'),
     notify    => Class['strongswan::service'],

--- a/manifests/conn.pp
+++ b/manifests/conn.pp
@@ -11,6 +11,7 @@
 #        'auth'    => 'PSK', 'key' => 'xYsdfkjkasd' },
 #      { 'left_id' => '10.0.0.2', 'right_id' => '%any',
 #        'auth'    => 'PSK', 'key' => 'xYsdfkjkasd' },
+#      { 'auth' => 'RSA', 'key' => "${::fqdn}.pem" },
 #    ]
 #
 # === Authors

--- a/spec/defines/conn_spec.rb
+++ b/spec/defines/conn_spec.rb
@@ -29,4 +29,28 @@ describe 'strongswan::conn', :type => 'define' do
         'content' => /foo2=bar2/)
     end
   end
+
+  context 'sample-pubkey-connection' do
+    let(:params) {{
+      :params => {
+        'left'      => '1.2.3.4',
+        'leftcert'  => 'foo.example.dev',
+        'leftid'    => '@foo.example.dev.pem'
+        'right'     => '2.3.4.5',
+        'rightid'   => '@bar.example.dev',
+      },
+      :secrets => [
+        { 'auth' => 'RSA', 'key' => 'foo.example.dev.pem' },
+        { 'auth' => 'ECDSA', 'key' => 'bar.example.dev.pem',
+          'passphrase' => 'foobar'}
+      ],
+    }}
+    it do
+      should compile.with_all_deps
+      should contain_file('/etc/ipsec.d/secrets/ipsec.unittest.secrets').with(
+        'content' => /: RSA foo.example.dev.pem/)
+      should contain_file('/etc/ipsec.d/secrets/ipsec.unittest.secrets').with(
+        'content' => /: ECDSA bar.example.dev.pem "foobar"/)
+    end
+  end
 end

--- a/spec/defines/conn_spec.rb
+++ b/spec/defines/conn_spec.rb
@@ -35,7 +35,7 @@ describe 'strongswan::conn', :type => 'define' do
       :params => {
         'left'      => '1.2.3.4',
         'leftcert'  => 'foo.example.dev',
-        'leftid'    => '@foo.example.dev.pem'
+        'leftid'    => '@foo.example.dev.pem',
         'right'     => '2.3.4.5',
         'rightid'   => '@bar.example.dev',
       },

--- a/templates/ipsec.conn.secrets.erb
+++ b/templates/ipsec.conn.secrets.erb
@@ -1,6 +1,11 @@
-# Strongswan Connection Secrets File: <% @name %>
+# Strongswan Connection Secrets File: <% @title %>
 #
 # * Managed by Puppet, do not modify *
 #
-<% @secrets.each do |v| %><%= v['left_id'] %> <%= v['right_id'] %> : <%= v['auth'] %> "<%= v['key'] %>"
-<% end -%>
+<% @secrets.each do |v|
+     if ['RSA', 'ECDSA'].include?(v['auth']) -%>
+: <%= v['auth'] %> <%= v['key'] %><% if v.key?('passphrase') %> "<%= v['passphrase'] %>"<% end %>
+<%   else -%>
+<%= v['left_id'] %> <%= v['right_id'] %> : <%= v['auth'] %> "<%= v['key'] %>"
+<%   end
+   end -%>

--- a/templates/ipsec.conn.secrets.erb
+++ b/templates/ipsec.conn.secrets.erb
@@ -1,4 +1,4 @@
-# Strongswan Connection Secrets File: <% @title %>
+# Strongswan Connection Secrets File: <%= @title %>
 #
 # * Managed by Puppet, do not modify *
 #


### PR DESCRIPTION
This PR adds various tweaks for the `strongswan::conn` secrets file:
- Adds better support for specifying RSA and ECDSA private key files for connections that use public key authentication.
- Manages the secrets file only when the `secrets` parameter isn't empty.
- Sets the [`backup`](https://docs.puppetlabs.com/references/latest/type.html#file-attribute-backup) attribute to `false` for the secrets file resource.
