### PR TITLE
Refactor hard coded service provider to a configurable setting

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -17,9 +17,10 @@ class strongswan::env {
                           'strongswan-plugin-xauth-pam' ]
 
   # Service configuration options
-  $service_name   = 'strongswan'
-  $service_ensure = 'running'
-  $service_enable = true
+  $service_name     = 'strongswan'
+  $service_provider = 'upstart'
+  $service_ensure   = 'running'
+  $service_enable   = true
 
   # Where do we store all of the custom connection configs?
   $conn_conf_path    = '/etc/ipsec.d/conns'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,10 @@
 #   Name of the StrongSwan service daemon.
 #   (default: strongswan)
 #
+# [*service_provider*]
+#   The service backend to use.
+#   (default: upstart)
+#
 # [*service_ensure*]
 #   Whether to ensure the service is running or not.
 #   (default: running)
@@ -54,6 +58,7 @@ class strongswan (
   $ipsec_options      = {},
   $secrets_conf_path  = $strongswan::env::secrets_conf_path,
   $service_name       = $strongswan::env::service_name,
+  $service_provider   = $strongswan::env::service_provider,
   $service_ensure     = $strongswan::env::service_ensure,
   $service_enable     = $strongswan::env::service_enable,
   $strongswan_package = $strongswan::env::strongswan_package,
@@ -82,6 +87,7 @@ class strongswan (
   class { 'strongswan::service':
     ensure    => $service_ensure,
     service   => $service_name,
+    provider  => $service_provider,
     enable    => $service_enable,
     subscribe => Class['strongswan::config'],
     require   => Class['strongswan::config'];

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,13 +7,14 @@
 # Matt Wise <matt@nextdoor.com>
 #
 class strongswan::service (
-  $service = $strongswan::env::service_name,
-  $ensure  = $strongswan::env::service_ensure,
-  $enable  = $strongswan::env::service_enable,
+  $service  = $strongswan::env::service_name,
+  $provider = $strongswan::env::service_provider,
+  $ensure   = $strongswan::env::service_ensure,
+  $enable   = $strongswan::env::service_enable,
 ) inherits strongswan::env {
   service { 'strongswan':
     ensure     => $ensure,
-    provider   => 'upstart',
+    provider   => $provider,
     name       => $service,
     enable     => $enable,
     hasstatus  => true,


### PR DESCRIPTION
Ubuntu 16.04 and newer have adopted the systemd init system, thus it
should be possible to change which backend to use when installing and
setting up strongswan.