### PR TITLE
Updated readme with refactored service provider setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Name of the StrongSwan service daemon.
 
 #### `service_provider`
 Name of the init system to use e.g. 'upstart' or 'systemd'.
-(_default: upstart)
+(_default: upstart_)
 
 #### `service_ensure`
 Whether to ensure the service is running or not.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ class { 'strongswan':
   ipsec_options      => <ipsec options>,
   secrets_conf_path  => <path to store secrets>,
   service_name       => <ipsec service name>,
+  service_provider   => <init system name>,
   service_ensure     => <ipsec service ensure>,
   service_enable     => <ipsec service enable bool>,
   strongswan_package => <strongswan package name>,
@@ -57,6 +58,10 @@ Directory to store individual IPSec Connection secret files in.
 #### `service_name`
 Name of the StrongSwan service daemon.
 (_default: strongswan_)
+
+#### `service_provider`
+Name of the init system to use e.g. 'upstart' or 'systemd'.
+(_default: upstart)
 
 #### `service_ensure`
 Whether to ensure the service is running or not.


### PR DESCRIPTION
I noticed the version I got from installing the module using 
puppet module install Nextdoor-strongswan
is different from the one on Github I guess maybe it is because of the travis build failed for https://github.com/Nextdoor/puppet-strongswan/pull/9

anyway I updated the readme with the service_provider option after some hours debugging on ubuntu 16.04 and upstart..