### PR TITLE
Remove a Ruby Version, add a Puppet Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ script:
   - "bundle exec rake lint"
   - "bundle exec rake spec SPEC_OPTS='--format documentation --color'"
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:
  - PUPPET_GEM_VERSION="~> 3.4.0"
  - PUPPET_GEM_VERSION="~> 3.5.0"
+ - PUPPET_GEM_VERSION="~> 5.3.2"


### PR DESCRIPTION
It looks just like Travis is having a hard time with Ruby 1.8.7 in general... and frankly no one should be using it at this point. Removing support for it from the travis tests, and adding a new version of PUppet too.