### PR TITLE
service - service_provider agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ class { 'strongswan':
   ipsec_options      => <ipsec options>,
   secrets_conf_path  => <path to store secrets>,
   service_name       => <ipsec service name>,
-  service_provider   => <init system name>,
   service_ensure     => <ipsec service ensure>,
   service_enable     => <ipsec service enable bool>,
   strongswan_package => <strongswan package name>,
@@ -58,10 +57,6 @@ Directory to store individual IPSec Connection secret files in.
 #### `service_name`
 Name of the StrongSwan service daemon.
 (_default: strongswan_)
-
-#### `service_provider`
-Name of the init system to use e.g. 'upstart' or 'systemd'.
-(_default: upstart_)
 
 #### `service_ensure`
 Whether to ensure the service is running or not.

--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -18,7 +18,6 @@ class strongswan::env {
 
   # Service configuration options
   $service_name     = 'strongswan'
-  $service_provider = 'upstart'
   $service_ensure   = 'running'
   $service_enable   = true
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,10 +25,6 @@
 #   Name of the StrongSwan service daemon.
 #   (default: strongswan)
 #
-# [*service_provider*]
-#   The service backend to use.
-#   (default: upstart)
-#
 # [*service_ensure*]
 #   Whether to ensure the service is running or not.
 #   (default: running)
@@ -58,7 +54,6 @@ class strongswan (
   $ipsec_options      = {},
   $secrets_conf_path  = $strongswan::env::secrets_conf_path,
   $service_name       = $strongswan::env::service_name,
-  $service_provider   = $strongswan::env::service_provider,
   $service_ensure     = $strongswan::env::service_ensure,
   $service_enable     = $strongswan::env::service_enable,
   $strongswan_package = $strongswan::env::strongswan_package,
@@ -88,7 +83,6 @@ class strongswan (
   class { 'strongswan::service':
     ensure    => $service_ensure,
     service   => $service_name,
-    provider  => $service_provider,
     enable    => $service_enable,
     subscribe => Class['strongswan::config'],
     require   => Class['strongswan::config'];

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,13 +8,11 @@
 #
 class strongswan::service (
   $service  = $strongswan::env::service_name,
-  $provider = $strongswan::env::service_provider,
   $ensure   = $strongswan::env::service_ensure,
   $enable   = $strongswan::env::service_enable,
 ) inherits strongswan::env {
   service { 'strongswan':
     ensure     => $ensure,
-    provider   => $provider,
     name       => $service,
     enable     => $enable,
     hasstatus  => true,


### PR DESCRIPTION
Provider doesn't need to provided as puppet will detect this under normal circumstances. This sets us up for Xenial (systemd) support.