### PR TITLE
Update meraki vpn preset with DH Group 2

### DIFF
--- a/manifests/presets/meraki_vpn.pp
+++ b/manifests/presets/meraki_vpn.pp
@@ -57,7 +57,7 @@ define strongswan::presets::meraki_vpn (
     'auto'          => 'add',
     'ikelifetime'   => '8h',
     'keyexchange'   => 'ikev1',
-    'ike'           => '3des-sha1',
+    'ike'           => '3des-sha1-modp1024',
     'esp'           => 'aes256-sha1-noesn',
     'keylife'       => '8h',
     'rekey'         => 'no',


### PR DESCRIPTION
Strongswan version 5.6.2 requires the DH group to be included.

```
Apr  9 05:21:23.256535 localhost charon[3294]: 06[CFG] a DH group is mandatory in IKE proposals
Apr  9 05:21:23.256535 localhost charon[3294]: 06[CFG] skipped invalid proposal string: 3des-sha1
```

DH Groups found here: https://wiki.strongswan.org/projects/strongswan/wiki/IKEv1CipherSuites#Diffie-Hellman-Groups